### PR TITLE
fix overflow, hitting effective deposit rate < 1 b/c vterra growth in…

### DIFF
--- a/contracts/market/src/borrow.rs
+++ b/contracts/market/src/borrow.rs
@@ -8,6 +8,7 @@ use moneymarket::interest_model::BorrowRateResponse;
 use moneymarket::market::{BorrowerInfoResponse, BorrowerInfosResponse};
 use moneymarket::overseer::BorrowLimitResponse;
 use moneymarket::querier::{deduct_tax, query_balance, query_supply};
+use moneymarket::vterra::compute_vterra_exchange_rate;
 
 use crate::deposit::compute_exchange_rate_raw;
 use crate::error::ContractError;
@@ -313,7 +314,8 @@ pub fn compute_interest_raw(
 
     let mut exchange_rate =
         compute_exchange_rate_raw(state, block_height, aterra_supply, vterra_supply, balance);
-    let effective_deposit_rate = exchange_rate / state.prev_aterra_exchange_rate;
+    dbg!(&exchange_rate, state.prev_aterra_exchange_rate);
+    let effective_deposit_rate = dbg!(exchange_rate / state.prev_aterra_exchange_rate);
     let deposit_rate = (effective_deposit_rate - Decimal256::one()) / passed_blocks;
 
     if deposit_rate > target_deposit_rate {

--- a/contracts/market/src/migration.rs
+++ b/contracts/market/src/migration.rs
@@ -51,7 +51,7 @@ pub(crate) fn migrate(deps: DepsMut, block_height: u64, msg: MigrateMsg) -> StdR
             prev_aterra_supply: old_state.prev_aterra_supply,
             prev_aterra_exchange_rate: old_state.prev_exchange_rate,
             // new
-            prev_ve_premium_rate: vterra_state.premium_rate,
+            prev_vterra_premium_rate: vterra_state.premium_rate,
             prev_vterra_exchange_rate: vterra_state.prev_epoch_vterra_exchange_rate,
             prev_vterra_supply: vterra_state.vterra_supply,
             vterra_exchange_rate_last_updated: block_height,

--- a/contracts/market/src/state.rs
+++ b/contracts/market/src/state.rs
@@ -46,7 +46,7 @@ pub struct State {
     pub prev_vterra_exchange_rate: Decimal256,
     pub vterra_exchange_rate_last_updated: u64,
     /// Premium rate in blocks. Updated during epoch update
-    pub prev_ve_premium_rate: Decimal256,
+    pub prev_vterra_premium_rate: Decimal256,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/market/src/testing/deposit_ut.rs
+++ b/contracts/market/src/testing/deposit_ut.rs
@@ -36,7 +36,7 @@ fn proper_compute_exchange_rate() {
         &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::from(1000000u128))],
     )]);
 
-    let mock_state = State {
+    let mut mock_state = State {
         total_liabilities: Decimal256::from_uint256(50000u128),
         total_reserves: Decimal256::from_uint256(550000u128),
         last_interest_updated: env.block.height,
@@ -54,7 +54,7 @@ fn proper_compute_exchange_rate() {
         deps.as_ref(),
         env.block.height,
         &mock_config,
-        &mock_state,
+        &mut mock_state,
         mock_deposit_amount,
     )
     .unwrap();

--- a/contracts/market/src/testing/tests.rs
+++ b/contracts/market/src/testing/tests.rs
@@ -35,7 +35,7 @@ pub(crate) fn get_mock_state() -> State {
         prev_vterra_supply: Uint256::zero(),
         prev_vterra_exchange_rate: Decimal256::one(),
         vterra_exchange_rate_last_updated: mock_env().block.height,
-        prev_ve_premium_rate: Decimal256::percent(0),
+        prev_vterra_premium_rate: Decimal256::percent(0),
     }
 }
 

--- a/contracts/vterra/src/bonding.rs
+++ b/contracts/vterra/src/bonding.rs
@@ -252,7 +252,7 @@ pub fn claim_unlocked_aterra(
 /// Exchange rate of aterra / vterra
 /// ex: 1 ve * ER => ER aterra
 pub(crate) fn compute_ve_exchange_rate(state: &State, block_height: u64) -> Decimal256 {
-    moneymarket::vterra::compute_ve_exchange_rate(
+    moneymarket::vterra::compute_vterra_exchange_rate(
         state.prev_epoch_vterra_exchange_rate,
         state.premium_rate,
         state.last_updated,

--- a/contracts/vterra/src/contract.rs
+++ b/contracts/vterra/src/contract.rs
@@ -169,7 +169,7 @@ pub fn receive_cw20(
 ) -> Result<Response, ContractError> {
     let contract_addr = info.sender;
     match from_binary(&cw20_msg.msg) {
-        Ok(Cw20HookMsg::UnbondVeATerra {}) => {
+        Ok(Cw20HookMsg::UnbondVTerra {}) => {
             // only asset contract can execute this message
             let config: Config = read_config(deps.storage)?;
             if deps.api.addr_canonicalize(contract_addr.as_str())? != config.vterra_contract {

--- a/contracts/vterra/src/testing/mod.rs
+++ b/contracts/vterra/src/testing/mod.rs
@@ -118,7 +118,7 @@ fn unbond_simple() {
     let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
         sender: MOCK_USER.to_string(),
         amount: Uint128::from(10_000u64),
-        msg: to_binary(&Cw20HookMsg::UnbondVeATerra {}).unwrap(),
+        msg: to_binary(&Cw20HookMsg::UnbondVTerra {}).unwrap(),
     });
     let info = mock_info(VTERRA_CONTRACT, &[]);
     let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();

--- a/packages/moneymarket/src/vterra.rs
+++ b/packages/moneymarket/src/vterra.rs
@@ -83,7 +83,7 @@ pub enum Cw20HookMsg {
     BondATerra {},
 
     /// Burn vterra and entitle sender to claim corresponding aterra after 30 day waiting period
-    UnbondVeATerra {},
+    UnbondVTerra {},
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -132,7 +132,7 @@ pub struct StateResponse {
 
 /// Exchange rate of aterra / vterra
 /// ex: 1 ve * ER => ER aterra
-pub fn compute_ve_exchange_rate(
+pub fn compute_vterra_exchange_rate(
     previous_er: Decimal256,
     premium_rate: Decimal256,
     last_updated: u64,
@@ -142,14 +142,28 @@ pub fn compute_ve_exchange_rate(
     if blocks_elapsed == 0 {
         previous_er
     } else {
-        previous_er * pow(premium_rate, blocks_elapsed)
+        dbg!("");
+        dbg!(blocks_elapsed);
+        dbg!(previous_er);
+        dbg!(premium_rate);
+        dbg!(previous_er * dbg!(pow(premium_rate, blocks_elapsed)))
     }
 }
 
 pub fn pow(base: Decimal256, power: u64) -> Decimal256 {
-    let mut acc = Decimal256::one();
-    for _ in 0..power {
-        acc = acc * base
-    }
-    acc
+    pow_by_squaring(base, power)
+    // let mut acc = Decimal256::one();
+    // for _ in 0..power {
+    //     acc = acc * base;
+    // }
+    // acc
+}
+
+fn pow_by_squaring(x: Decimal256, n: u64) -> Decimal256 {
+    match n {
+        0 => Decimal256::one(),
+        1 => x,
+        i if i % 2 == 0 => pow_by_squaring(x * x, n / 2),
+        _ => x * pow_by_squaring(x * x, (n - 1) / 2),
+    }     
 }


### PR DESCRIPTION
fixed overflow
now hitting effective aUST deposit rate < 1 error 
This is bc vterra appreciates over the epoch while no new flows come in to increase the ER. This specific error won't happen in prod because the ER is above 1.0....01, but I'm not sure how to manipulate the testing env to have a more realistic ER. 
